### PR TITLE
chore(deps): use zio-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 .vscode/
 .metals/
 token.conf
+since.conf

--- a/build.sc
+++ b/build.sc
@@ -50,9 +50,7 @@ class CoreModule(val crossScalaVersion: String) extends ExtendedCrossScalaModule
     ivy"com.softwaremill.sttp.client3::core:${sttpVersion}",
     ivy"com.softwaremill.sttp.client3::zio-json:${sttpVersion}",
     ivy"com.softwaremill.sttp.client3::zio:${sttpVersion}",
-    ivy"com.github.pureconfig::pureconfig:${pureConfigVersion}",
-    // https://github.com/com-lihaoyi/mill/issues/1797
-    ivy"org.scala-lang:scala-reflect:${crossScalaVersion}"
+    ivy"com.github.pureconfig::pureconfig-core:${pureConfigVersion}"
   )
 
   override def scalacOptions = Seq(

--- a/build.sc
+++ b/build.sc
@@ -10,6 +10,7 @@ object Versions {
   val zioLoggingVersion     = "2.1.3"
   val zioVersion            = "2.0.3"
   val zioJsonVersion        = "0.3.0"
+  val zioConfigVersion      = "3.0.2"
   val sttpVersion           = "3.8.3"
   val pureConfigVersion     = "0.17.2"
   val scalafixModuleVersion = "0.6.0"
@@ -46,11 +47,13 @@ class CoreModule(val crossScalaVersion: String) extends ExtendedCrossScalaModule
   override def ivyDeps = Agg(
     ivy"dev.zio::zio:${zioVersion}",
     ivy"dev.zio::zio-json:${zioJsonVersion}",
+    ivy"dev.zio::zio-config:${zioConfigVersion}",
+    ivy"dev.zio::zio-config-magnolia:${zioConfigVersion}",
+    ivy"dev.zio::zio-config-typesafe:${zioConfigVersion}",
     ivy"dev.zio::zio-logging:${zioLoggingVersion}",
     ivy"com.softwaremill.sttp.client3::core:${sttpVersion}",
     ivy"com.softwaremill.sttp.client3::zio-json:${sttpVersion}",
-    ivy"com.softwaremill.sttp.client3::zio:${sttpVersion}",
-    ivy"com.github.pureconfig::pureconfig-core:${pureConfigVersion}"
+    ivy"com.softwaremill.sttp.client3::zio:${sttpVersion}"
   )
 
   override def scalacOptions = Seq(

--- a/core/resources/bot.conf
+++ b/core/resources/bot.conf
@@ -1,6 +1,0 @@
-matrix {
-    api-prefix="/_matrix"
-    api-version="v3"
-    home-server="https://matrix.org"
-    user-id="ziobot"
-}

--- a/core/src/com/bot4s/zmatrix/MatrixConfiguration.scala
+++ b/core/src/com/bot4s/zmatrix/MatrixConfiguration.scala
@@ -2,9 +2,8 @@ package com.bot4s.zmatrix
 
 import zio._
 
-import pureconfig.ConfigSource
+import pureconfig._
 import pureconfig.error.ConfigReaderFailures
-import pureconfig.generic.auto._
 
 final case class Config(
   matrix: MatrixConfigurationContent
@@ -32,6 +31,12 @@ object MatrixConfiguration {
   val DEFAULT_API_PREFIX  = "/_matrix"
   val DEFAULT_API_VERSION = "v3"
   val DEFAULT_CONFIG_FILE = "bot.conf"
+
+  private implicit val matrixContentConfigReader: ConfigReader[MatrixConfigurationContent] =
+    ConfigReader.forProduct6("home-server", "api-prefix", "api-version", "user-id", "device-name", "device-id")(
+      MatrixConfigurationContent(_, _, _, _, _, _)
+    )
+  private implicit val configReader: ConfigReader[Config] = ConfigReader.forProduct1("matrix")(Config(_))
 
   def get: URIO[MatrixConfiguration, Config] = ZIO.serviceWithZIO(_.get)
 

--- a/core/src/com/bot4s/zmatrix/client/MatrixClient.scala
+++ b/core/src/com/bot4s/zmatrix/client/MatrixClient.scala
@@ -26,14 +26,13 @@ object MatrixClient {
     ZLayer.fromFunction(LiveMatrixClient.apply _)
 }
 
-final case class LiveMatrixClient(backend: SttpBackend[Task, Any], matrixConfig: MatrixConfiguration)
-    extends MatrixClient {
+final case class LiveMatrixClient(backend: SttpBackend[Task, Any], config: MatrixConfiguration) extends MatrixClient {
 
   override def send(
     request: JsonRequest
   ): IO[MatrixError, Json] =
     for {
-      config <- matrixConfig.get
+      _ <- ZIO.unit
       prefix = request.scope match {
                  case ApiScope.Client => config.matrix.clientApi
                  case ApiScope.Media  => config.matrix.mediaApi

--- a/core/src/com/bot4s/zmatrix/models/AccessToken.scala
+++ b/core/src/com/bot4s/zmatrix/models/AccessToken.scala
@@ -5,7 +5,5 @@ import zio.json._
 final case class AccessToken(token: String) extends AnyVal
 
 object AccessToken {
-  // We want to support both the derivation with the token field and also a flattened "anyval" decoding
-  implicit val roomIdDecoder: JsonDecoder[AccessToken] =
-    DeriveJsonDecoder.gen[AccessToken] orElse JsonDecoder[String].map(AccessToken.apply)
+  implicit val roomIdDecoder: JsonDecoder[AccessToken] = JsonDecoder[String].map(AccessToken.apply)
 }

--- a/core/src/com/bot4s/zmatrix/models/RoomEvent.scala
+++ b/core/src/com/bot4s/zmatrix/models/RoomEvent.scala
@@ -35,11 +35,11 @@ object RoomEvent {
     content: Json
   ) extends RoomEvent
 
-  implicit val roomMessageDecoder: JsonDecoder[MessageEvent]                = DeriveJsonDecoder.gen[MessageEvent]
-  implicit val topicMessageContentDecoder: JsonDecoder[TopicMessageContent] = DeriveJsonDecoder.gen[TopicMessageContent]
-  implicit val topicMessageDecoder: JsonDecoder[TopicEvent]                 = DeriveJsonDecoder.gen[TopicEvent]
+  implicit val roomMessageDecoder: JsonDecoder[MessageEvent]                = DeriveJsonDecoder.gen
+  implicit val topicMessageContentDecoder: JsonDecoder[TopicMessageContent] = DeriveJsonDecoder.gen
+  implicit val topicMessageDecoder: JsonDecoder[TopicEvent]                 = DeriveJsonDecoder.gen
 
-  implicit val roomEventDecoder = JsonDecoder[Json].mapOrFail { json =>
+  implicit val roomEventDecoder: JsonDecoder[RoomEvent] = JsonDecoder[Json].mapOrFail { json =>
     json.get(JsonCursor.field("type")).flatMap(_.as[String]).flatMap {
       case "m.room.message" => json.as[MessageEvent]
       case "m.room.topic"   => json.as[TopicEvent]

--- a/core/src/com/bot4s/zmatrix/models/RoomId.scala
+++ b/core/src/com/bot4s/zmatrix/models/RoomId.scala
@@ -7,10 +7,10 @@ final case class RoomId(id: String) extends AnyVal
 object RoomId {
 
   implicit val roomIdDecoder: JsonDecoder[RoomId] =
-    DeriveJsonDecoder.gen[RoomId] orElse JsonDecoder[String].map(RoomId.apply)
+    JsonDecoder[String].map(RoomId.apply)
 
   implicit val roomIdEncoder: JsonEncoder[RoomId] =
-    DeriveJsonEncoder.gen[RoomId]
+    JsonEncoder.string.contramap[RoomId](_.id)
 
   implicit val roomIdKeyEncoder: JsonFieldEncoder[RoomId] =
     JsonFieldEncoder.string.contramap[RoomId](_.id)

--- a/core/src/com/bot4s/zmatrix/services/Authentication.scala
+++ b/core/src/com/bot4s/zmatrix/services/Authentication.scala
@@ -28,30 +28,29 @@ object Authentication {
   val live = ZLayer.fromZIO(
     ZIO
       .environmentWithZIO[MatrixEnv] { env =>
-        env.get[MatrixConfiguration].get.flatMap { config =>
-          Ref.make(AccessToken(sys.env.getOrElse("MATRIX_BOT_ACCESS", ""))).map { tokenRef =>
-            new Authentication {
-              def accessToken: UIO[AccessToken] = tokenRef.get
+        val config = env.get[MatrixConfiguration]
+        Ref.make(AccessToken(sys.env.getOrElse("MATRIX_BOT_ACCESS", ""))).map { tokenRef =>
+          new Authentication {
+            def accessToken: UIO[AccessToken] = tokenRef.get
 
-              def refresh: IO[MatrixError, AccessToken] =
-                (config.matrix.userId, sys.env.get("MATRIX_BOT_PASSWORD")) match {
-                  case (Some(userId), Some(password)) =>
-                    Matrix
-                      .passwordLogin(
-                        user = userId,
-                        password = password,
-                        deviceId = config.matrix.deviceId
-                      )
-                      .flatMap(response => tokenRef.updateAndGet(_ => response.accessToken))
-                      .provideEnvironment(env)
-                  case (Some(_), _) =>
-                    ZIO.fail(
-                      MatrixError.InvalidParameterError("password", "Missing password, please set MATRIX_BOT_PASSWORD")
+            def refresh: IO[MatrixError, AccessToken] =
+              (config.matrix.userId, sys.env.get("MATRIX_BOT_PASSWORD")) match {
+                case (Some(userId), Some(password)) =>
+                  Matrix
+                    .passwordLogin(
+                      user = userId,
+                      password = password,
+                      deviceId = config.matrix.deviceId
                     )
-                  case (None, _) =>
-                    ZIO.fail(MatrixError.InvalidParameterError("userId", "user-id is not defined in configuration"))
-                }
-            }
+                    .flatMap(response => tokenRef.updateAndGet(_ => response.accessToken))
+                    .provideEnvironment(env)
+                case (Some(_), _) =>
+                  ZIO.fail(
+                    MatrixError.InvalidParameterError("password", "Missing password, please set MATRIX_BOT_PASSWORD")
+                  )
+                case (None, _) =>
+                  ZIO.fail(MatrixError.InvalidParameterError("userId", "user-id is not defined in configuration"))
+              }
           }
         }
       }

--- a/core/test/src/com/bot4s/zmatrix/SerializationSpec.scala
+++ b/core/test/src/com/bot4s/zmatrix/SerializationSpec.scala
@@ -125,7 +125,6 @@ object SerializationSpec extends ZIOSpecDefault {
       },
       test("RoomId") {
         assert(""""test"""".fromJson[RoomId])(isRight(equalTo(RoomId("test"))))
-        assert("""{"id": "test"}""".fromJson[RoomId])(isRight(equalTo(RoomId("test"))))
       },
       test("RoomMessageTextContent") {
         val content = """

--- a/examples/resources/bot.conf
+++ b/examples/resources/bot.conf
@@ -1,0 +1,6 @@
+matrix {
+    apiPrefix="/_matrix"
+    apiVersion="v3"
+    homeServer="https://matrix.org"
+    userId="ziobot"
+}

--- a/examples/src/com/bot4s/zmatrix/Runner.scala
+++ b/examples/src/com/bot4s/zmatrix/Runner.scala
@@ -25,6 +25,7 @@ object Runner extends ZIOAppDefault {
                    .mapError(_ => new Exception(s"Example '$input' does not exist"))
                    .tapError(e => printLineError(e.getMessage()))
       runnable <- example.run
+                    .tapError(e => printLineError(e.toString()))
     } yield runnable).retry(Schedule.forever).repeat(Schedule.forever)
   }
 

--- a/examples/src/com/bot4s/zmatrix/SimpleSync.scala
+++ b/examples/src/com/bot4s/zmatrix/SimpleSync.scala
@@ -28,7 +28,7 @@ object SimpleSync extends ExampleApp[Unit] {
   override def runExample: ZIO[AuthMatrixEnv, MatrixError, Unit] =
     for {
       _      <- Matrix.whoAmI.debug
-      config <- MatrixConfiguration.get
+      config <- ZIO.service[MatrixConfiguration]
       fromBot = (sender: String) => config.matrix.userId.exists(name => sender.startsWith(s"@$name"))
       _      <- pollLoop(fromBot).repeat(Schedule.spaced(10.seconds))
     } yield ()

--- a/examples/src/com/bot4s/zmatrix/Upload.scala
+++ b/examples/src/com/bot4s/zmatrix/Upload.scala
@@ -24,7 +24,7 @@ object Upload extends ExampleApp[Unit] {
   val runExample =
     (for {
       up     <- remoteUpload
-      config <- ZIO.service[MatrixConfiguration].flatMap(_.get)
+      config <- ZIO.service[MatrixConfiguration]
       _ <- printLine(
              s"Media uploaded, check out ${config.matrix.mediaApi}/download/${up.serverName}/${up.mediaId}"
            )


### PR DESCRIPTION
This is the last dependency preventing us from being compatible with Scala 3.
The auto-derivation was not that important here and writing those helper class is far from perfect but the configuration in this case is pretty static and will probably not change a lot in the future.

Types annotations were also added on implicits because this will be mandatory to cross-compile with scala 3.

The switch from pureconfig to zio-config happened to be harder than I though, there were mostly issues related to:
- Loading configuration from resources does not behave the same when running it from metals and from a jar/docker
- Loading configuration outside of resources if available
- Dealing with underlying errors (Pureconfig/Typesafe config is abstracting a lot of that for us)

However the error messages and parsing issue are better with zio-config and it will also make the the ecosystem a bit cleaner